### PR TITLE
Improve accuracy of server time estimates using HTTP Date header

### DIFF
--- a/serverDate.js
+++ b/serverDate.js
@@ -85,6 +85,36 @@ const createSample = (delayTime) => {
 
 
 /**
+ * Reppeatedly collect samples until a change in server date is detected
+ *
+ * @param {*} delayTime how long to wait in milliseconds between samples. higher values create fewer requests, but also decrease the precision of estimates made from them
+ * @param {*} sampleList a array to push samples onto
+ * @returns a promise that repeatedly collects samples until the server time changes
+ */
+const repeatedSample = (delayTime, sampleList) => {
+  return createSample(delayTime)
+    //store the sample
+    .then((sample) => {
+      sampleList.push(sample)
+    })
+    //conditionally schedule a new 
+    .then((sample) => {
+
+      const { requestDate, responseDate, serverDate } = sample
+      //if the server dates of the last 2 samples dont match, then we captured a request before and after the servers time ticked to the next second and we can stop making requests
+  
+      if (!hasCapturedTick(
+        sampleList[sampleList.lastIndexOf() - 1],
+        sampleList[sampleList.lastIndexOf()]
+        )) {
+        return repeatedSample(delayTime, sampleList)
+      }
+    })
+
+}
+
+
+/**
  * Determine whether two samples capture a change in the server's Datetime
  *
  * @param {*} lastSample the older sample

--- a/serverDate.js
+++ b/serverDate.js
@@ -76,11 +76,12 @@ const createDelay = (delayTime) => {
  * create a promise that delays, and then makes a new request as a sample
  *
  * @param {*} delayTime how long to delay in milliseconds
+ * @param {*} samplePromise a promise that executes the collection of a sample
  * @returns a promise that waits the specified time and then fetches a new sample
  */
-const createSample = (delayTime) => {
+const createSample = (delayTime, samplePromise) => {
   return createDelay(delayTime)
-    .then(fetchSampleImplementation)
+    .then(samplePromise)
 }
 
 
@@ -88,11 +89,12 @@ const createSample = (delayTime) => {
  * Reppeatedly collect samples until a change in server date is detected
  *
  * @param {*} delayTime how long to wait in milliseconds between samples. higher values create fewer requests, but also decrease the precision of estimates made from them
+ * @param {*} samplePromise a promise that executes the collection of a sample
  * @param {*} sampleList a array to push samples onto
  * @returns a promise that repeatedly collects samples until the server time changes
  */
-const repeatedSample = (delayTime, sampleList) => {
-  return createSample(delayTime)
+const repeatedSample = (delayTime, sampleList, samplePromise) => {
+  return createSample(delayTime, samplePromise)
     //store the sample
     .then((sample) => {
       sampleList.push(sample)

--- a/serverDate.js
+++ b/serverDate.js
@@ -56,3 +56,29 @@ export const getServerDate = async (
 
   return best;
 };
+
+
+/**
+ * creates a promise that delays a set  number of milliseconds
+ * 
+ * @param {*} delayTime  the number of milliseconds to delay
+ */
+const createDelay = (delayTime) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delayTime);
+  })
+}
+
+
+/**
+ * create a promise that delays, and then makes a new request as a sample
+ *
+ * @param {*} delayTime how long to delay in milliseconds
+ * @returns a promise that waits the specified time and then fetches a new sample
+ */
+const createSample = (delayTime) => {
+  return createDelay(delayTime)
+    .then(fetchSampleImplementation)
+}

--- a/serverDate.js
+++ b/serverDate.js
@@ -82,3 +82,15 @@ const createSample = (delayTime) => {
   return createDelay(delayTime)
     .then(fetchSampleImplementation)
 }
+
+
+/**
+ * Determine whether two samples capture a change in the server's Datetime
+ *
+ * @param {*} lastSample the older sample
+ * @param {*} thisSamplethe newer sample
+ * @returns boolean indicating whether the server's date value changed between these requests
+ */
+const hasCapturedTick = (lastSample, thisSample) => {
+  return lastSample.serverDate.getTime() !== thisSample.serverDate.getTime()
+}

--- a/serverDate.js
+++ b/serverDate.js
@@ -5,20 +5,24 @@
 const fetchSampleImplementation = async () => {
   const requestDate = new Date();
 
-  const { headers, ok, statusText } = await fetch(window.location, {
+  return fetch(window.location, {
     cache: `no-store`,
     method: `HEAD`,
-  });
+  })
+    .then( result => {
+      const { headers, ok, statusText } = result
+      
+      if (!ok) {
+        throw new Error(`Bad date sample from server: ${statusText}`);
+      }
 
-  if (!ok) {
-    throw new Error(`Bad date sample from server: ${statusText}`);
-  }
-
-  return {
-    requestDate,
-    responseDate: new Date(),
-    serverDate: new Date(headers.get(`Date`)),
-  };
+      return {
+        requestDate,
+        responseDate: new Date(),
+        serverDate: new Date(headers.get(`Date`)),
+      };
+    })
+    .catch((error) => console.error(error))
 };
 
 export const getServerDate = async (


### PR DESCRIPTION
This PR fixes #41. it is not quite ready for merging as it still likely needs a few more cleanup/release-prep type things (although these may depends on @NodeGuy's discretion as to whether they are actually necessary):

- [ ] version number bump (thinking `5.1.0` for this one as its a pretty significant nonbreaking change)
- [ ] write/update unit tests
    - [ ] set up mocking for fetchSampleImplementation 
- [ ] check to make sure examples etc. still work (this shouldn't be a breaking change so they should)
- [ ] might also be nice to set up a build step/github action to compile the inline JSdoc comments into some static HTML (or host it on github pages)