### PR TITLE
return offset 0 and local Date if there's a error fetching; option to…

### DIFF
--- a/serverDate.js
+++ b/serverDate.js
@@ -22,9 +22,9 @@ const fetchSampleImplementation = async () => {
 };
 
 export const getServerDate = async (
-  { fetchSample } = { fetchSample: fetchSampleImplementation }
+  { fetchSample, throwErrors } = { fetchSample: fetchSampleImplementation, throwErrors: false }
 ) => {
-  let best = { uncertainty: Number.MAX_VALUE };
+  let best = { date: new Date(), offset: 0, uncertainty: Number.MAX_VALUE };
 
   // Fetch 10 samples to increase the chance of getting one with low
   // uncertainty.
@@ -46,7 +46,8 @@ export const getServerDate = async (
         };
       }
     } catch (exception) {
-      console.warn(exception);
+      if (throwErrors) throw exception;
+      else console.warn(exception);
     }
   }
 

--- a/serverDate.js
+++ b/serverDate.js
@@ -22,13 +22,15 @@ const fetchSampleImplementation = async () => {
 };
 
 export const getServerDate = async (
-  { fetchSample, throwErrors } = { fetchSample: fetchSampleImplementation, throwErrors: false }
+  { fetchSample, withErrors } = { fetchSample: fetchSampleImplementation, withErrors: false }
 ) => {
+  const fetchCount = 10;
+  const errors = [];
   let best = { date: new Date(), offset: 0, uncertainty: Number.MAX_VALUE };
 
   // Fetch 10 samples to increase the chance of getting one with low
   // uncertainty.
-  for (let index = 0; index < 10; index++) {
+  for (let index = 0; index < fetchCount; index++) {
     try {
       const { requestDate, responseDate, serverDate } = await fetchSample();
 
@@ -46,10 +48,10 @@ export const getServerDate = async (
         };
       }
     } catch (exception) {
-      if (throwErrors) throw exception;
-      else console.warn(exception);
+      errors.push(exception);
+      console.warn(exception);
     }
   }
 
-  return best;
+  return withErrors ? { ...best, errors, fetchCount } : best;
 };

--- a/test.js
+++ b/test.js
@@ -77,3 +77,20 @@ it(`synchronizes the time with the server`, async () => {
     uncertainty: 582.5,
   });
 });
+
+it(`returns offset 0 and local Date on error`, async () => {
+  const fetchSample = async () => {
+    throw new Error(`oh dang`);
+  };
+  const { date, offset, uncertainty } = await getServerDate({ fetchSample });
+  assert(offset === 0);
+  assert(uncertainty === Number.MAX_VALUE);
+  assert(Date.now() - date < 100);
+})
+
+it(`throws errors if you ask it to`, async () => {
+  const fetchSample = async () => {
+    throw new Error(`oh dang`);
+  };
+  await assert.rejects(async () => getServerDate({ fetchSample, throwErrors: true }));
+})

--- a/test.js
+++ b/test.js
@@ -88,9 +88,11 @@ it(`returns offset 0 and local Date on error`, async () => {
   assert(Date.now() - date < 100);
 })
 
-it(`throws errors if you ask it to`, async () => {
+it(`reports errors if you ask it to`, async () => {
   const fetchSample = async () => {
     throw new Error(`oh dang`);
   };
-  await assert.rejects(async () => getServerDate({ fetchSample, throwErrors: true }));
+  const { errors, fetchCount } = await getServerDate({ fetchSample, withErrors: true });
+  assert(errors.length === fetchCount);
+  assert(errors[0].message === `oh dang`);
 })


### PR DESCRIPTION
… throw errors instead of console.warn


Love how nifty & succinct this is.

I just added `{ date: new Date(), offset: 0 }` to the return value if there's an error fetching,
(so for example it won't break in server-side-rendering scenarios, where client code might run on the server)

and added an option to rethrow errors instead of swallowing them with console.warn.

Thanks for the good code!